### PR TITLE
Add source-map support by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     require('babel-plugin-syntax-async-functions'),
     require('babel-plugin-transform-runtime'),
     require('babel-plugin-transform-async-to-generator'),
-    require('babel-plugin-transform-strict-mode')
+    require('babel-plugin-transform-strict-mode'),
+    require('babel-plugin-source-map-support-for-6').default
   ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taskcluster",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Babel Presets for Taskcluster",
   "main": "index.js",
   "repository": "taskcluster/babel-preset-taskcluster",
@@ -14,6 +14,7 @@
     "babel-plugin-syntax-async-functions": "6.8.0",
     "babel-plugin-transform-async-to-generator": "6.8.0",
     "babel-plugin-transform-runtime": "6.8.0",
-    "babel-plugin-transform-strict-mode": "6.8.0"
+    "babel-plugin-transform-strict-mode": "6.8.0",
+    "babel-plugin-source-map-support-for-6": "0.0.5"
   }
 }


### PR DESCRIPTION
`babel-plugin-source-map-support-for-6` seems a bit sketchy owing it to being a fork due to [this issue](https://github.com/chocolateboy/babel-plugin-source-map-support/issues/1#issuecomment-166334536). I've pinned the version exactly in `package.json` for now. If that's not desirable we can work something else out. I think we can move back to the normal `babel-plugin-source-map-support` eventually.

I've tested this out with `npm link` and one of our projects locally. It seems to work just fine.
