### PR TITLE
Use peerdependency for old versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taskcluster",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Babel Presets for Taskcluster",
   "main": "index.js",
   "repository": "taskcluster/babel-preset-taskcluster",
@@ -10,11 +10,14 @@
   },
   "homepage": "https://github.com/taskcluster/babel-preset-taskcluster#readme",
   "dependencies": {
-    "babel-preset-es2015": "6.6.0",
+    "babel-plugin-source-map-support-for-6": "0.0.5",
     "babel-plugin-syntax-async-functions": "6.8.0",
     "babel-plugin-transform-async-to-generator": "6.8.0",
     "babel-plugin-transform-runtime": "6.8.0",
     "babel-plugin-transform-strict-mode": "6.8.0",
-    "babel-plugin-source-map-support-for-6": "0.0.5"
+    "babel-preset-es2015": "6.6.0"
+  },
+  "peerDependencies": {
+    "source-map-support": "^0.2.10"
   }
 }


### PR DESCRIPTION
The `source-map-support` stuff from the last change I made was only working on `node >= 5`. This should fix the issue. I've tested it locally with `npm pack` and a version of each of node 0.12, 4, and 5.

Anything to do with peerDependencies makes my head hurt, so I'm mostly requesting a sanity check.
