### PR TITLE
Remove source-map-suopport due to dependency footgun.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ module.exports = {
     require('babel-plugin-syntax-async-functions'),
     require('babel-plugin-transform-runtime'),
     require('babel-plugin-transform-async-to-generator'),
-    require('babel-plugin-transform-strict-mode'),
-    require('babel-plugin-source-map-support-for-6').default
+    require('babel-plugin-transform-strict-mode')
   ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-taskcluster",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Babel Presets for Taskcluster",
   "main": "index.js",
   "repository": "taskcluster/babel-preset-taskcluster",
@@ -14,7 +14,6 @@
     "babel-plugin-syntax-async-functions": "6.8.0",
     "babel-plugin-transform-async-to-generator": "6.8.0",
     "babel-plugin-transform-runtime": "6.8.0",
-    "babel-plugin-transform-strict-mode": "6.8.0",
-    "babel-plugin-source-map-support-for-6": "0.0.5"
+    "babel-plugin-transform-strict-mode": "6.8.0"
   }
 }


### PR DESCRIPTION
This is probably the safest thing for us to do. It means a bit of extra work in all of our services and libraries to make source-map-support work, but that's not the end of the world.
